### PR TITLE
setItem() returns the set value in the promise

### DIFF
--- a/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java
+++ b/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java
@@ -43,7 +43,7 @@ public class RNSensitiveInfoModule extends ReactContextBaseJavaModule {
 
         try {
             putExtra(key, value, prefs(name));
-            pm.resolve(null);
+            pm.resolve(value);
         } catch (Exception e) {
             Log.d("RNSensitiveInfo", e.getCause().getMessage());
             pm.reject(e);

--- a/ios/RNSensitiveInfo/RNSensitiveInfo.m
+++ b/ios/RNSensitiveInfo/RNSensitiveInfo.m
@@ -65,7 +65,7 @@ NSDictionary * makeError(NSError *error)
 }
 
 
-RCT_EXPORT_METHOD(setItem:(NSString*)key value:(NSString*)value options:(NSDictionary *)options){
+RCT_EXPORT_METHOD(setItem:(NSString*)key value:(NSString*)value options:(NSDictionary *)options resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject){
 
     NSString * keychainService = [RCTConvert NSString:options[@"keychainService"]];
     if (keychainService == NULL) {
@@ -81,6 +81,8 @@ RCT_EXPORT_METHOD(setItem:(NSString*)key value:(NSString*)value options:(NSDicti
 
     OSStatus osStatus = SecItemDelete((__bridge CFDictionaryRef) query);
     osStatus = SecItemAdd((__bridge CFDictionaryRef) query, NULL);
+
+    resolve(value);
 }
 
 RCT_EXPORT_METHOD(getItem:(NSString *)key options:(NSDictionary *)options resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject){


### PR DESCRIPTION
This is really useful when you have a chain of promises and storing the value is in the middle

Right now we need to something like
```
awesomeMethodThatPromisesASensitiveValue()
.then(sensitiveValue =>
                    SInfo.setItem(id, sensitiveValue, {encript: true})
                        .then(() => cvv) //so we can chain the promise
).then(sensitiveValue => doSomethingWithTheValue(sensitiveValue))
```

after this change it can be simplified to
```
awesomeMethodThatPromisesASensitiveValue()
.then(sensitiveValue => SInfo.setItem(id, sensitiveValue, {encript: true}))
.then(sensitiveValue => doSomethingWithTheValue(sensitiveValue))
```

I modified the code within my node_modules and works for both platforms, but please give it a double check as my ObjectiveC is more than basic.
