### PR TITLE
support biometry type evaluation from isSensorAvailable

### DIFF
--- a/ios/RNSensitiveInfo/RNSensitiveInfo.m
+++ b/ios/RNSensitiveInfo/RNSensitiveInfo.m
@@ -267,7 +267,12 @@ RCT_EXPORT_METHOD(isSensorAvailable:(RCTPromiseResolveBlock)resolve rejecter:(RC
     LAContext *context = [[LAContext alloc] init];
 
     if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:NULL]) {
-        resolve(@(YES));
+        if (@available(iOS 11, *)) {
+            if (context.biometryType == LABiometryTypeFaceID) {
+                return resolve(@"Face ID");
+            }
+        }
+        resolve(@"Touch ID");
     } else {
         resolve(@(NO));
     }


### PR DESCRIPTION
This updates `isSensorAvailable` for iOS to resolve with the biometry type `"Face ID"` or `"Touch ID"` if it is available. It still resolves with `false` if it's not.

This should be compatible with existing usage in JS since the strings are still truthy, but this allows us to customize the display more without reliance on other libraries.