### PR TITLE
Fixing the "java.lang.NullPointerException" at RNSensitiveInfo module

### DIFF
--- a/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java
+++ b/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java
@@ -55,7 +55,7 @@ public class RNSensitiveInfoModule extends ReactContextBaseJavaModule {
         try {
             initKeyStore(reactContext);
         } catch (Exception e) {
-            Log.d("RNSensitiveInfo", e.getCause().getMessage());
+            Log.d("RNSensitiveInfo", Log.getStackTraceString(e));
         }
     }
 
@@ -74,7 +74,7 @@ public class RNSensitiveInfoModule extends ReactContextBaseJavaModule {
             try {
                 value = decrypt(value);
             } catch (Exception e) {
-                Log.d("RNSensitiveInfo", e.getCause().getMessage());
+                Log.d("RNSensitiveInfo", Log.getStackTraceString(e));
             }
         }
 
@@ -90,7 +90,7 @@ public class RNSensitiveInfoModule extends ReactContextBaseJavaModule {
             putExtra(key, value, prefs(name));
             pm.resolve(null);
         } catch (Exception e) {
-            Log.d("RNSensitiveInfo", e.getCause().getMessage());
+            Log.d("RNSensitiveInfo", Log.getStackTraceString(e));
             pm.reject(e);
         }
     }
@@ -122,7 +122,7 @@ public class RNSensitiveInfoModule extends ReactContextBaseJavaModule {
             try {
                 value = decrypt(value);
             } catch (Exception e) {
-                Log.d("RNSensitiveInfo", e.getCause().getMessage());
+                Log.d("RNSensitiveInfo", Log.getStackTraceString(e));
             }
             resultData.putString(entry.getKey(), value);
         }
@@ -259,7 +259,13 @@ public class RNSensitiveInfoModule extends ReactContextBaseJavaModule {
 
 
     public String decrypt(String encrypted) throws Exception {
+        if (encrypted == null) {
+            Exception cause = new RuntimeException("Invalid argument at decrypt function");
+            throw new RuntimeException("encrypted argument can't be null", cause);
+        }
+
         Cipher c;
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             c = Cipher.getInstance(AES_GCM);
             c.init(Cipher.DECRYPT_MODE, secretKey, new GCMParameterSpec(128, FIXED_IV));


### PR DESCRIPTION
# Context

A weird error (describe at #73) was being raised at [RNSensitiveInfoModule](https://github.com/mCodex/react-native-sensitive-info/blob/keystore/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java).   After some investigation, me and @luisfmsouza have discovered that the root cause was a problem at the error handling on the `catch` block of the [getAllItems](https://github.com/mCodex/react-native-sensitive-info/blob/keystore/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java#L125) function. This was happening because some exceptions caused at decrypt function doesn't have an explicit cause and because of that, the getCause() at the getAllItems' catch was returning null and trying to call the getMessage(). Which is not possible, of course.


# Changes:

  - changed the getAllItems method error handling to log the error stack trace instead of the `getCause().getMessage()` chain. This was needed because some exceptions caused at decrypt function doesn't have an explicit cause and because of that, the getCause() at the getAllItems' catch was returning null and trying to call the getMessage(). Which is not possible, of course.
  - added a new argument validation at decrypt method, checking if the encrypted attribute is null;

Closes #73 