### PR TITLE
Handle the case of mFingerprintManager being null

### DIFF
--- a/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java
+++ b/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java
@@ -76,7 +76,7 @@ public class RNSensitiveInfoModule extends ReactContextBaseJavaModule {
      */
     private boolean hasSetupFingerprint() {
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && mFingerprintManager != null) {
                 if (!mFingerprintManager.isHardwareDetected()) {
                     return false;
                 } else if (!mFingerprintManager.hasEnrolledFingerprints()) {


### PR DESCRIPTION
In my Genymotion emulator, it seems the FingerprintManager service is not returned in the constructor. This is a fix to stop the app from crashing outright and to fallback to rejecting fingerprint setup in this very rare case.