### PR TITLE
Fix NoSuchKeyException

### DIFF
--- a/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java
+++ b/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java
@@ -125,7 +125,7 @@ public class RNSensitiveInfoModule extends ReactContextBaseJavaModule {
 
         if (value != null && options.hasKey("touchID") && options.getBoolean("touchID")) {
             boolean showModal = options.hasKey("showModal") && options.getBoolean("showModal");
-            HashMap strings = options.getMap("strings").toHashMap();
+            HashMap strings = options.hasKey("strings") ? options.getMap("strings").toHashMap() : new HashMap();
 
             decryptWithAes(value, showModal, strings, pm, null);
         } else {


### PR DESCRIPTION
There is a case where trying to get "strings" from the map fails and React Native crashes on Android with a NoSuchKeyException. This code should check if the "strings" key exists and if not return a new HashMap instead.