### PR TITLE
Handle the case of FingerprintManager being unavailable on some Android M+ devices

### DIFF
--- a/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java
+++ b/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java
@@ -57,7 +57,11 @@ public class RNSensitiveInfoModule extends ReactContextBaseJavaModule {
     public RNSensitiveInfoModule(ReactApplicationContext reactContext) {
         super(reactContext);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            mFingerprintManager = (FingerprintManager) reactContext.getSystemService(Context.FINGERPRINT_SERVICE);
+            try {
+                mFingerprintManager = (FingerprintManager) reactContext.getSystemService(Context.FINGERPRINT_SERVICE);
+            } catch (Exception e) {
+                Log.d("RNSensitiveInfo", "Fingerprint not supported");
+            }
             initKeyStore();
         }
     }


### PR DESCRIPTION
This PR proposes try-catching the instantiating of FingerprintManager. This prevents app crashes on certain devices where original code would cause an NPE.