### PR TITLE
Fix wrong build tools version in RN 0.56

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 27
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
React Native 0.56 has moved to newer build tools for android and exported versions with gradle variables.

This PR uses variables declared in project instead of hardcoded versions and fixes build on RN 0.56.