### PR TITLE
Fixed Android Fragment's Lifecycle Handling

### DIFF
--- a/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java
+++ b/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java
@@ -226,30 +226,32 @@ public class RNSensitiveInfoModule extends ReactContextBaseJavaModule {
         }
     }
 
-    private void showDialog(final HashMap strings, FingerprintManager.CryptoObject cryptoObject, FingerprintUiHelper.Callback callback) {
-        // DialogFragment.show() will take care of adding the fragment
-        // in a transaction.  We also want to remove any currently showing
-        // dialog, so make our own transaction and take care of that here.
+    private void showDialog(final HashMap strings, Object cryptoObject, FingerprintUiHelper.Callback callback) {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+            // DialogFragment.show() will take care of adding the fragment
+            // in a transaction.  We also want to remove any currently showing
+            // dialog, so make our own transaction and take care of that here.
 
-        Activity activity = getCurrentActivity();
-        if (activity == null) {
-            callback.onError(AppConstants.E_INIT_FAILURE,
-                    strings.containsKey("cancelled") ? strings.get("cancelled").toString() : "Authentication was cancelled");
-            return;
+            Activity activity = getCurrentActivity();
+            if (activity == null) {
+                callback.onError(AppConstants.E_INIT_FAILURE,
+                        strings.containsKey("cancelled") ? strings.get("cancelled").toString() : "Authentication was cancelled");
+                return;
+            }
+
+            FragmentTransaction ft = activity.getFragmentManager().beginTransaction();
+            Fragment prev = getCurrentActivity().getFragmentManager().findFragmentByTag(AppConstants.DIALOG_FRAGMENT_TAG);
+            if (prev != null) {
+                ft.remove(prev);
+            }
+            ft.addToBackStack(null);
+
+            // Create and show the dialog.
+            FingerprintAuthenticationDialogFragment newFragment = FingerprintAuthenticationDialogFragment.newInstance(strings);
+            newFragment.setCryptoObject((FingerprintManager.CryptoObject) cryptoObject);
+            newFragment.setCallback(callback);
+            newFragment.show(ft, AppConstants.DIALOG_FRAGMENT_TAG);
         }
-
-        FragmentTransaction ft = activity.getFragmentManager().beginTransaction();
-        Fragment prev = getCurrentActivity().getFragmentManager().findFragmentByTag(AppConstants.DIALOG_FRAGMENT_TAG);
-        if (prev != null) {
-            ft.remove(prev);
-        }
-        ft.addToBackStack(null);
-
-        // Create and show the dialog.
-        FingerprintAuthenticationDialogFragment newFragment = FingerprintAuthenticationDialogFragment.newInstance(strings);
-        newFragment.setCryptoObject(cryptoObject);
-        newFragment.setCallback(callback);
-        newFragment.show(ft, AppConstants.DIALOG_FRAGMENT_TAG);
     }
 
     /**

--- a/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java
+++ b/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java
@@ -1,5 +1,8 @@
 package br.com.classapp.RNSensitiveInfo;
 
+import android.app.Activity;
+import android.app.Fragment;
+import android.app.FragmentTransaction;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.hardware.fingerprint.FingerprintManager;
@@ -223,6 +226,32 @@ public class RNSensitiveInfoModule extends ReactContextBaseJavaModule {
         }
     }
 
+    private void showDialog(final HashMap strings, FingerprintManager.CryptoObject cryptoObject, FingerprintUiHelper.Callback callback) {
+        // DialogFragment.show() will take care of adding the fragment
+        // in a transaction.  We also want to remove any currently showing
+        // dialog, so make our own transaction and take care of that here.
+
+        Activity activity = getCurrentActivity();
+        if (activity == null) {
+            callback.onError(AppConstants.E_INIT_FAILURE,
+                    strings.containsKey("cancelled") ? strings.get("cancelled").toString() : "Authentication was cancelled");
+            return;
+        }
+
+        FragmentTransaction ft = activity.getFragmentManager().beginTransaction();
+        Fragment prev = getCurrentActivity().getFragmentManager().findFragmentByTag(AppConstants.DIALOG_FRAGMENT_TAG);
+        if (prev != null) {
+            ft.remove(prev);
+        }
+        ft.addToBackStack(null);
+
+        // Create and show the dialog.
+        FingerprintAuthenticationDialogFragment newFragment = FingerprintAuthenticationDialogFragment.newInstance(strings);
+        newFragment.setCryptoObject(cryptoObject);
+        newFragment.setCallback(callback);
+        newFragment.show(ft, AppConstants.DIALOG_FRAGMENT_TAG);
+    }
+
     /**
      * Generates a new AES key and stores it under the { @code KEY_ALIAS_AES } in the
      * Android Keystore.
@@ -298,12 +327,7 @@ public class RNSensitiveInfoModule extends ReactContextBaseJavaModule {
                             }
 
                             // Show the fingerprint dialog
-                            FingerprintAuthenticationDialogFragment fragment
-                                    = FingerprintAuthenticationDialogFragment.newInstance(strings);
-                            fragment.setCryptoObject(new FingerprintManager.CryptoObject(cipher));
-                            fragment.setCallback(new PutExtraWithAESCallback());
-
-                            fragment.show(getCurrentActivity().getFragmentManager(), AppConstants.DIALOG_FRAGMENT_TAG);
+                            showDialog(strings, new FingerprintManager.CryptoObject(cipher), new PutExtraWithAESCallback());
 
                         } else {
                             mCancellationSignal = new CancellationSignal();
@@ -414,12 +438,7 @@ public class RNSensitiveInfoModule extends ReactContextBaseJavaModule {
                             }
 
                             // Show the fingerprint dialog
-                            FingerprintAuthenticationDialogFragment fragment
-                                    = FingerprintAuthenticationDialogFragment.newInstance(strings);
-                            fragment.setCryptoObject(new FingerprintManager.CryptoObject(cipher));
-                            fragment.setCallback(new DecryptWithAesCallback());
-
-                            fragment.show(getCurrentActivity().getFragmentManager(), AppConstants.DIALOG_FRAGMENT_TAG);
+                            showDialog(strings, new FingerprintManager.CryptoObject(cipher), new DecryptWithAesCallback());
 
                         } else {
                             mCancellationSignal = new CancellationSignal();

--- a/android/src/main/java/br/com/classapp/RNSensitiveInfo/utils/AppConstants.java
+++ b/android/src/main/java/br/com/classapp/RNSensitiveInfo/utils/AppConstants.java
@@ -6,4 +6,5 @@ public interface AppConstants {
 
     // error codes
     String E_AUTHENTICATION_CANCELLED = "E_AUTHENTICATION_CANCELLED";
+    String E_INIT_FAILURE = "E_INIT_FAILURE";
 }

--- a/android/src/main/java/br/com/classapp/RNSensitiveInfo/view/Fragments/FingerprintUiHelper.java
+++ b/android/src/main/java/br/com/classapp/RNSensitiveInfo/view/Fragments/FingerprintUiHelper.java
@@ -94,6 +94,7 @@ public class FingerprintUiHelper extends FingerprintManager.AuthenticationCallba
     @Override
     public void onAuthenticationError(final int errMsgId, final CharSequence errString) {
         if (!mSelfCancelled) {
+            mCancelButton.setEnabled(false);
             showError(errString);
             mIcon.postDelayed(new Runnable() {
                 @Override


### PR DESCRIPTION
* Fixed an issue where `dismiss()` would be called on Fragment when it was paused.
* Fixed edge case where callbacks and dismisses could be called multiple times