### PR TITLE
Add modern keys to control keychain access.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,8 @@ export enum RNSensitiveInfoAccessControlOptions {
   'kSecAccessControlTouchIDAny',
   'kSecAccessControlTouchIDCurrentSet',
   'kSecAccessControlUserPresence',
+  'kSecAccessControlBiometryAny',
+  'kSecAccessControlBiometryCurrentSet',
 }
 
 export enum RNSensitiveInfoAttrAccessibleOptions {

--- a/ios/RNSensitiveInfo/RNSensitiveInfo.m
+++ b/ios/RNSensitiveInfo/RNSensitiveInfo.m
@@ -34,6 +34,12 @@ CFStringRef convertkSecAttrAccessible(NSString* key){
     if([key isEqual: @"kSecAttrAccessibleAlwaysThisDeviceOnly"]){
         return kSecAttrAccessibleAlwaysThisDeviceOnly;
     }
+    if ([key isEqual: @"kSecAccessControlBiometryAny"]) {
+        return kSecAccessControlBiometryAny;
+    }
+    if ([key isEqual: @"kSecAccessControlBiometryCurrentSet"]) {
+        return kSecAccessControlBiometryCurrentSet;
+    }
     return kSecAttrAccessibleWhenUnlocked;
 }
 


### PR DESCRIPTION
This keys replace deprecated ones that was specific to TouchID,
and allow to use FaceID feature as well (tested on iPhone X device).

Fix #109 