### PR TITLE
Change TS types to use string literals instead enums, and added missing methods

### DIFF
--- a/RNSensitiveInfo.js
+++ b/RNSensitiveInfo.js
@@ -1,3 +1,21 @@
-import { NativeModules } from 'react-native';
+import { NativeModules } from "react-native";
 
-module.exports = NativeModules.RNSensitiveInfo;
+const RNSensitiveInfo = NativeModules.RNSensitiveInfo;
+
+module.exports = {
+  ...RNSensitiveInfo,
+  setInvalidatedByBiometricEnrollment() {
+    if (RNSensitiveInfo.setInvalidatedByBiometricEnrollment == null) {
+      return;
+    }
+
+    return RNSensitiveInfo.setInvalidatedByBiometricEnrollment();
+  },
+  cancelFingerprintAuth() {
+    if (RNSensitiveInfo.cancelFingerprintAuth == null) {
+      return;
+    }
+
+    return RNSensitiveInfo.cancelFingerprintAuth();
+  }
+};

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,43 +1,65 @@
-export enum RNSensitiveInfoBiometryType {
-  "Touch ID",
-  "Face ID",
-}
+type RNSensitiveInfoBiometryType = "Touch ID" | "Face ID";
 
-export enum RNSensitiveInfoAccessControlOptions {
-  'kSecAccessControlApplicationPassword',
-  'kSecAccessControlPrivateKeyUsage',
-  'kSecAccessControlDevicePasscode',
-  'kSecAccessControlTouchIDAny',
-  'kSecAccessControlTouchIDCurrentSet',
-  'kSecAccessControlUserPresence',
-  'kSecAccessControlBiometryAny',
-  'kSecAccessControlBiometryCurrentSet',
-}
+type RNSensitiveInfoAccessControlOptions =
+  | "kSecAccessControlApplicationPassword"
+  | "kSecAccessControlPrivateKeyUsage"
+  | "kSecAccessControlDevicePasscode"
+  | "kSecAccessControlTouchIDAny"
+  | "kSecAccessControlTouchIDCurrentSet"
+  | "kSecAccessControlUserPresence"
+  | "kSecAccessControlBiometryAny"
+  | "kSecAccessControlBiometryCurrentSet";
 
-export enum RNSensitiveInfoAttrAccessibleOptions {
-  'kSecAttrAccessibleAfterFirstUnlock',
-  'kSecAttrAccessibleAlways',
-  'kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly',
-  'kSecAttrAccessibleWhenUnlockedThisDeviceOnly',
-  'kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly',
-  'kSecAttrAccessibleAlwaysThisDeviceOnly',
-  'kSecAttrAccessibleWhenUnlocked',
+type RNSensitiveInfoAttrAccessibleOptions =
+  | "kSecAttrAccessibleAfterFirstUnlock"
+  | "kSecAttrAccessibleAlways"
+  | "kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly"
+  | "kSecAttrAccessibleWhenUnlockedThisDeviceOnly"
+  | "kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly"
+  | "kSecAttrAccessibleAlwaysThisDeviceOnly"
+  | "kSecAttrAccessibleWhenUnlocked";
+
+interface RNSensitiveInfoAndroidDialogStrings {
+  header?: string;
+  description?: string;
+  hint?: string;
+  success?: string;
+  notRecognized?: string;
+  cancel?: string;
+  cancelled?: string;
 }
 
 export interface RNSensitiveInfoOptions {
   kSecAccessControl?: RNSensitiveInfoAccessControlOptions;
   kSecAttrAccessible?: RNSensitiveInfoAttrAccessibleOptions;
   keychainService?: string;
-  kSecUseOperationPrompt?: string;
   sharedPreferencesName?: string;
   touchID?: boolean;
+  showModal?: boolean;
+  kSecUseOperationPrompt?: string;
+  strings?: RNSensitiveInfoAndroidDialogStrings;
 }
 
-export declare function setItem(key: string, value: string, options: RNSensitiveInfoOptions): Promise<null>;
-export declare function getItem(key: string, options: RNSensitiveInfoOptions): Promise<string>;
-export declare function getAllItems(options: RNSensitiveInfoOptions): Promise<Object>;
-export declare function deleteItem(key: string, options: RNSensitiveInfoOptions): Promise<null>;
-export declare function isSensorAvailable(): Promise<RNSensitiveInfoBiometryType | boolean>;
+export declare function setItem(
+  key: string,
+  value: string,
+  options: RNSensitiveInfoOptions
+): Promise<null>;
+export declare function getItem(
+  key: string,
+  options: RNSensitiveInfoOptions
+): Promise<string>;
+export declare function getAllItems(
+  options: RNSensitiveInfoOptions
+): Promise<Object>;
+export declare function deleteItem(
+  key: string,
+  options: RNSensitiveInfoOptions
+): Promise<null>;
+export declare function isSensorAvailable(): Promise<
+  RNSensitiveInfoBiometryType | boolean
+>;
 export declare function isHardwareDetected(): Promise<boolean>;
 export declare function hasEnrolledFingerprints(): Promise<boolean>;
 export declare function cancelFingerprintAuth(): void;
+export declare function setInvalidatedByBiometricEnrollment(boolean): void;


### PR DESCRIPTION
`RNSensitiveInfoAccessControlOptions` and `RNSensitiveInfoAttrAccessibleOptions` was changed to string literals by following reasons:
- `enum`s in declaration files should be declared as `const` to be able to import it to source code, but it works not well for instance with [babel](https://babeljs.io/docs/en/babel-plugin-transform-typescript#caveats);
- String literals using heavily in RN [types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-native/index.d.ts#L571), so it's a common practice.

Some available methods was missing, but are using in docs and examples.