### PR TITLE
Detect that biometry is locked

### DIFF
--- a/ios/RNSensitiveInfo/RNSensitiveInfo.m
+++ b/ios/RNSensitiveInfo/RNSensitiveInfo.m
@@ -272,8 +272,9 @@ RCT_EXPORT_METHOD(isSensorAvailable:(RCTPromiseResolveBlock)resolve rejecter:(RC
 {
 #if !TARGET_OS_TV
     LAContext *context = [[LAContext alloc] init];
-
-    if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:NULL]) {
+    
+    NSError *evaluationError = nil;
+    if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&evaluationError]) {
         if (@available(iOS 11, macOS 10.13.2, *)) {
             if (context.biometryType == LABiometryTypeFaceID) {
                 return resolve(@"Face ID");
@@ -281,6 +282,9 @@ RCT_EXPORT_METHOD(isSensorAvailable:(RCTPromiseResolveBlock)resolve rejecter:(RC
         }
         resolve(@"Touch ID");
     } else {
+        if (evaluationError && evaluationError.code == LAErrorBiometryLockout) {
+            return reject(nil, @"Biometry is locked", nil);
+        }
         resolve(@(NO));
     }
 #else


### PR DESCRIPTION
I have a case when just boolean is not enough for sensor availability and it's needed to know for sure that sensor was locked due to many failed attempts.

I don't think that `isSensorAvailable` method is actually a good place for this, cause his semantic is about availability, not about specific errors, but on other hand I don't know a better place for this error right now.

Thanks for your time.