### PR TITLE
Returning getItem() error description to JS

### DIFF
--- a/ios/RNSensitiveInfo/RNSensitiveInfo.m
+++ b/ios/RNSensitiveInfo/RNSensitiveInfo.m
@@ -179,7 +179,11 @@ RCT_EXPORT_METHOD(getItem:(NSString *)key options:(NSDictionary *)options resolv
                 localizedReason:prompt
                           reply:^(BOOL success, NSError * _Nullable error) {
                               if (!success) {
-                                  reject(nil, @"The user name or passphrase you entered is not correct.", nil);
+                                  if (error) {
+                                      reject(nil, error.localizedDescription, error);
+                                  } else {
+                                      reject(nil, @"The user name or passphrase you entered is not correct.", nil);
+                                  }
                                   return;
                               }
                               


### PR DESCRIPTION
I wasn't able to distinguish when the user hits canceled or when the user's retry limit exceeded, therefore this change is able to return the actual error back to the JS side to help me identify them