### PR TITLE
Correctly set type of parameter of setInvalidatedByBiometricEnrollment

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -62,4 +62,4 @@ export declare function isSensorAvailable(): Promise<
 export declare function isHardwareDetected(): Promise<boolean>;
 export declare function hasEnrolledFingerprints(): Promise<boolean>;
 export declare function cancelFingerprintAuth(): void;
-export declare function setInvalidatedByBiometricEnrollment(boolean): void;
+export declare function setInvalidatedByBiometricEnrollment(set: boolean): void;


### PR DESCRIPTION
## Context
While running a react native project in Typescript with this library included, I ran into the following Typescript issue:

```
node_modules/react-native-sensitive-info/index.d.ts:65:61 - error TS7006: Parameter 'boolean' implicitly has an 'any' type.

65 export declare function setInvalidatedByBiometricEnrollment(boolean): void;
```

This was caused by the fact that in the type definition above, `boolean` is the name of the parameter (while it probably was intended to be the type of the parameter).

## What has been done?
- Give the parameter of `setInvalidatedByBiometricEnrollment` an explicit name and type it

## How to test?
- Include this file in a typescript project
- See no error