### PR TITLE
Add ability to sync Keychain items w/ iCloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,13 @@ SInfo.setItem('key1', 'value1', {
 
 Note: By default `kSecAccessControl` will get set to `kSecAccessControlUserPresence`.
 
+#### kSecAttrSynchronizable
+
+You can set this to `true` in order to sync the keychain items with iCloud.
+
+Note: By default `kSecAttrSynchronizable` will get set to `false`.
+
+
 # How to use?
 
 Here is a simple example:

--- a/ios/RNSensitiveInfo/RNSensitiveInfo.m
+++ b/ios/RNSensitiveInfo/RNSensitiveInfo.m
@@ -124,6 +124,10 @@ RCT_EXPORT_METHOD(setItem:(NSString*)key value:(NSString*)value options:(NSDicti
                                       valueData, kSecValueData,
                                       key, kSecAttrAccount, nil];
 
+    if([RCTConvert BOOL:options[@"kSecAttrSynchronizable"]]){
+        [query setValue:@YES forKey:(NSString *)kSecAttrSynchronizable];
+    }
+
     if([RCTConvert BOOL:options[@"touchID"]]){
         CFStringRef kSecAccessControlValue = convertkSecAccessControl([RCTConvert NSString:options[@"kSecAccessControl"]]);
         SecAccessControlRef sac = SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, kSecAccessControlValue, NULL);
@@ -155,6 +159,7 @@ RCT_EXPORT_METHOD(getItem:(NSString *)key options:(NSDictionary *)options resolv
     NSMutableDictionary* query = [NSMutableDictionary dictionaryWithObjectsAndKeys:(__bridge id)(kSecClassGenericPassword), kSecClass,
                                   keychainService, kSecAttrService,
                                   key, kSecAttrAccount,
+                                  kSecAttrSynchronizableAny, kSecAttrSynchronizable
                                   kCFBooleanTrue, kSecReturnAttributes,
                                   kCFBooleanTrue, kSecReturnData,
                                   nil];
@@ -224,6 +229,7 @@ RCT_EXPORT_METHOD(getAllItems:(NSDictionary *)options resolver:(RCTPromiseResolv
     
     NSMutableArray* finalResult = [[NSMutableArray alloc] init];
     NSMutableDictionary *query = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                  (__bridge id)kSecAttrSynchronizableAny, kSecAttrSynchronizable,
                                   (__bridge id)kCFBooleanTrue, (__bridge id)kSecReturnAttributes,
                                   (__bridge id)kSecMatchLimitAll, (__bridge id)kSecMatchLimit,
                                   (__bridge id)kCFBooleanTrue, (__bridge id)kSecReturnData,
@@ -285,6 +291,7 @@ RCT_EXPORT_METHOD(deleteItem:(NSString *)key options:(NSDictionary *)options res
     // Create dictionary of search parameters
     NSDictionary* query = [NSDictionary dictionaryWithObjectsAndKeys:
                           (__bridge id)(kSecClassGenericPassword), kSecClass,
+                          (__bridge id)(kSecAttrSynchronizableAny), kSecAttrSynchronizable,
                           keychainService, kSecAttrService,
                           key, kSecAttrAccount,
                           kCFBooleanTrue, kSecReturnAttributes,

--- a/ios/RNSensitiveInfo/RNSensitiveInfo.m
+++ b/ios/RNSensitiveInfo/RNSensitiveInfo.m
@@ -159,7 +159,7 @@ RCT_EXPORT_METHOD(getItem:(NSString *)key options:(NSDictionary *)options resolv
     NSMutableDictionary* query = [NSMutableDictionary dictionaryWithObjectsAndKeys:(__bridge id)(kSecClassGenericPassword), kSecClass,
                                   keychainService, kSecAttrService,
                                   key, kSecAttrAccount,
-                                  kSecAttrSynchronizableAny, kSecAttrSynchronizable
+                                  kSecAttrSynchronizableAny, kSecAttrSynchronizable,
                                   kCFBooleanTrue, kSecReturnAttributes,
                                   kCFBooleanTrue, kSecReturnData,
                                   nil];


### PR DESCRIPTION
Our motivation for this was that we had a React Native app that would use your library to store sensitive information, and we wanted to retrieve that same information from app extensions.

It's an admittedly ad-hoc solution, and if you'd like to explore more general ways of handling platform-specific keys I'd love to be of help.