### PR TITLE
Add pincode fallback Title (iOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,10 @@ You can set this to `true` in order to sync the keychain items with iCloud.
 
 Note: By default `kSecAttrSynchronizable` will get set to `false`.
 
+#### kLocalizedFallbackTitle
+
+You can set this to a string and fallback to pin code authentication.
+
 
 # How to use?
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,7 @@ export interface RNSensitiveInfoOptions {
   touchID?: boolean;
   showModal?: boolean;
   kSecUseOperationPrompt?: string;
+  kLocalizedFallbackTitle?: string;
   strings?: RNSensitiveInfoAndroidDialogStrings;
 }
 

--- a/ios/RNSensitiveInfo/RNSensitiveInfo.m
+++ b/ios/RNSensitiveInfo/RNSensitiveInfo.m
@@ -170,7 +170,8 @@ RCT_EXPORT_METHOD(getItem:(NSString *)key options:(NSDictionary *)options resolv
     
     if([RCTConvert BOOL:options[@"touchID"]]){
         LAContext *context = [[LAContext alloc] init];
-        context.localizedFallbackTitle = @"";
+        NSString *kLocalizedFallbackTitle = [RCTConvert NSString:options[@"kLocalizedFallbackTitle"]];
+        context.localizedFallbackTitle = kLocalizedFallbackTitle ? kLocalizedFallbackTitle : @"";
         context.touchIDAuthenticationAllowableReuseDuration = 1;
         
         [query setValue:context forKey:(NSString *)kSecUseAuthenticationContext];


### PR DESCRIPTION
Simply takes `kLocalizedFallbackTitle` option for iOS