### PR TITLE
Format android getAllItems data and ts types to match iOS implementation

### DIFF
--- a/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java
+++ b/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java
@@ -22,7 +22,9 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 

--- a/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java
+++ b/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java
@@ -188,20 +188,26 @@ public class RNSensitiveInfoModule extends ReactContextBaseJavaModule {
         pm.resolve(null);
     }
 
-
     @ReactMethod
     public void getAllItems(ReadableMap options, Promise pm) {
 
         String name = sharedPreferences(options);
 
         Map<String, ?> allEntries = prefs(name).getAll();
-        WritableMap resultData = new WritableNativeMap();
+        WritableArray resultData = new WritableNativeArray();
 
         for (Map.Entry<String, ?> entry : allEntries.entrySet()) {
-            String value = entry.getValue().toString();
-            resultData.putString(entry.getKey(), value);
+            WritableMap entryMap = new WritableNativeMap();
+
+            entryMap.putString("key", entry.getKey());
+            entryMap.putString("value", entry.getValue().toString());
+            entryMap.putString("service", name);
+            resultData.pushMap(entryMap);
         }
-        pm.resolve(resultData);
+
+        WritableArray resultWrapper = new WritableNativeArray();
+        resultWrapper.pushArray(resultData);
+        pm.resolve(resultWrapper);
     }
 
     @ReactMethod

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,9 +50,16 @@ export declare function getItem(
   key: string,
   options: RNSensitiveInfoOptions
 ): Promise<string>;
+
+interface SensitiveInfoEntry {
+  key: string
+  value: string
+  service: string
+}
 export declare function getAllItems(
   options: RNSensitiveInfoOptions
-): Promise<Object>;
+): Promise<[SensitiveInfoEntry[]]>;
+
 export declare function deleteItem(
   key: string,
   options: RNSensitiveInfoOptions


### PR DESCRIPTION
This change breaks the android return format, but matches the typescript definitions to the format in the iOS version of the native module.

I suggest a major version bump upon release to reflect the breaking change.