### PR TITLE
Fixed kSecAttrAccessible and kSecAccessControl mappings

### DIFF
--- a/ios/RNSensitiveInfo/RNSensitiveInfo.m
+++ b/ios/RNSensitiveInfo/RNSensitiveInfo.m
@@ -34,16 +34,10 @@ CFStringRef convertkSecAttrAccessible(NSString* key){
     if([key isEqual: @"kSecAttrAccessibleAlwaysThisDeviceOnly"]){
         return kSecAttrAccessibleAlwaysThisDeviceOnly;
     }
-    if ([key isEqual: @"kSecAccessControlBiometryAny"]) {
-        return kSecAccessControlBiometryAny;
-    }
-    if ([key isEqual: @"kSecAccessControlBiometryCurrentSet"]) {
-        return kSecAccessControlBiometryCurrentSet;
-    }
     return kSecAttrAccessibleWhenUnlocked;
 }
 
-CFStringRef convertkSecAccessControl(NSString* key){
+CFOptionFlags convertkSecAccessControl(NSString* key){
     if([key isEqual: @"kSecAccessControlApplicationPassword"]){
         return kSecAccessControlApplicationPassword;
     }
@@ -58,6 +52,12 @@ CFStringRef convertkSecAccessControl(NSString* key){
     }
     if([key isEqual: @"kSecAccessControlTouchIDCurrentSet"]){
         return kSecAccessControlTouchIDCurrentSet;
+    }
+    if ([key isEqual: @"kSecAccessControlBiometryAny"]) {
+        return kSecAccessControlBiometryAny;
+    }
+    if ([key isEqual: @"kSecAccessControlBiometryCurrentSet"]) {
+        return kSecAccessControlBiometryCurrentSet;
     }
     return kSecAccessControlUserPresence;
 }


### PR DESCRIPTION
kSecAccessControlBiometryAny and kSecAccessControlBiometryCurrentSet were incorrectly mapped under the convertkSecAttrAccessible function.
convertkSecAccessControl was also modified to return the correct CFType. The kSecAccessControl constants are essentially CFOptionFlags/SecAccessControlCreateFlags and not CFStringRefs.

The issue I observed was that setting kSecAccessControlBiometryAny or kSecAccessControlBiometryCurrentSet would cause the convertkSecAccessControl if blocks to fall through and kSecAccessControlUserPresence would be set instead.

This PR fixes that scenario. 