### PR TITLE
Update keychain credentials if they exist rather than deleting and re-adding

### DIFF
--- a/ios/RNSensitiveInfo/RNSensitiveInfo.m
+++ b/ios/RNSensitiveInfo/RNSensitiveInfo.m
@@ -118,11 +118,12 @@ RCT_EXPORT_METHOD(setItem:(NSString*)key value:(NSString*)value options:(NSDicti
     }
 
     NSData* valueData = [value dataUsingEncoding:NSUTF8StringEncoding];
-    NSMutableDictionary* query = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+    NSMutableDictionary* search = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                       (__bridge id)(kSecClassGenericPassword), kSecClass,
                                       keychainService, kSecAttrService,
-                                      valueData, kSecValueData,
                                       key, kSecAttrAccount, nil];
+    NSMutableDictionary *query = [search mutableCopy];
+    [query setValue: valueData forKey: kSecValueData];
 
     if([RCTConvert BOOL:options[@"kSecAttrSynchronizable"]]){
         [query setValue:@YES forKey:(NSString *)kSecAttrSynchronizable];
@@ -137,8 +138,24 @@ RCT_EXPORT_METHOD(setItem:(NSString*)key value:(NSString*)value options:(NSDicti
         [query setValue:(__bridge id _Nullable)(kSecAttrAccessibleValue) forKey:(NSString *)kSecAttrAccessible];
     }
 
-    OSStatus osStatus = SecItemDelete((__bridge CFDictionaryRef) query);
+    OSStatus osStatus;
     osStatus = SecItemAdd((__bridge CFDictionaryRef) query, NULL);
+    if (osStatus == errSecSuccess) {
+        resolve(value);
+        return;
+    }
+    if (osStatus == errSecDuplicateItem) {
+        NSDictionary *update = @{(__bridge id)kSecValueData:valueData};
+        osStatus = SecItemUpdate((__bridge CFDictionaryRef)search,
+                                 (__bridge CFDictionaryRef)update);
+        if (status == errSecSuccess) {
+            resolve(value);
+        } else {
+            NSError *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:osStatus userInfo:nil];
+            reject([NSString stringWithFormat:@"%ld", (long)error.code], [self messageForError:error], nil);
+            return;
+        }
+    }
     if (osStatus != noErr) {
         NSError *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:osStatus userInfo:nil];
         reject([NSString stringWithFormat:@"%ld",(long)error.code], [self messageForError:error], nil);

--- a/ios/RNSensitiveInfo/RNSensitiveInfo.m
+++ b/ios/RNSensitiveInfo/RNSensitiveInfo.m
@@ -152,7 +152,7 @@ RCT_EXPORT_METHOD(setItem:(NSString*)key value:(NSString*)value options:(NSDicti
         NSDictionary *update = @{(__bridge id)kSecValueData:valueData};
         osStatus = SecItemUpdate((__bridge CFDictionaryRef)search,
                                  (__bridge CFDictionaryRef)update);
-        if (status == errSecSuccess) {
+        if (osStatus == errSecSuccess) {
             resolve(value);
         } else {
             NSError *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:osStatus userInfo:nil];

--- a/ios/RNSensitiveInfo/RNSensitiveInfo.m
+++ b/ios/RNSensitiveInfo/RNSensitiveInfo.m
@@ -139,6 +139,10 @@ RCT_EXPORT_METHOD(setItem:(NSString*)key value:(NSString*)value options:(NSDicti
     }
 
     OSStatus osStatus;
+    //
+    // Instead of unconditionally deleting, try the add and if it fails with a duplicate item
+    // error, try an update.
+    //
     osStatus = SecItemAdd((__bridge CFDictionaryRef) query, NULL);
     if (osStatus == errSecSuccess) {
         resolve(value);

--- a/ios/RNSensitiveInfo/RNSensitiveInfo.m
+++ b/ios/RNSensitiveInfo/RNSensitiveInfo.m
@@ -152,13 +152,6 @@ RCT_EXPORT_METHOD(setItem:(NSString*)key value:(NSString*)value options:(NSDicti
         NSDictionary *update = @{(__bridge id)kSecValueData:valueData};
         osStatus = SecItemUpdate((__bridge CFDictionaryRef)search,
                                  (__bridge CFDictionaryRef)update);
-        if (osStatus == errSecSuccess) {
-            resolve(value);
-        } else {
-            NSError *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:osStatus userInfo:nil];
-            reject([NSString stringWithFormat:@"%ld", (long)error.code], [self messageForError:error], nil);
-            return;
-        }
     }
     if (osStatus != noErr) {
         NSError *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:osStatus userInfo:nil];


### PR DESCRIPTION
We have experienced intermittent cases of our production iOS app losing information stored keychain. We feel that using the update method instead of always deleting and re-adding will be safer. 