### PR TITLE
Add missing kSecAttrSynchronizable type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,7 @@ interface RNSensitiveInfoAndroidDialogStrings {
 export interface RNSensitiveInfoOptions {
   kSecAccessControl?: RNSensitiveInfoAccessControlOptions;
   kSecAttrAccessible?: RNSensitiveInfoAttrAccessibleOptions;
+  kSecAttrSynchronizable?: boolean;
   keychainService?: string;
   sharedPreferencesName?: string;
   touchID?: boolean;


### PR DESCRIPTION
I noticed this type is referenced in the documentation but isn't part of the TypeScript module definition.

This PR adds it to the types.