### PR TITLE
fix(android): same callback logic between showModal options

### DIFF
--- a/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java
+++ b/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java
@@ -363,7 +363,8 @@ public class RNSensitiveInfoModule extends ReactContextBaseJavaModule {
 
                                 @Override
                                 public void onAuthenticationFailed() {
-                                    pm.reject(AppConstants.E_AUTHENTICATION_NOT_RECOGNIZED, strings.containsKey("notRecognized") ? strings.get("notRecognized").toString() : "Fingerprint not recognized, try again");
+                                    getReactApplicationContext().getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                                            .emit("FINGERPRINT_AUTHENTICATION_HELP", "Fingerprint not recognized.");
                                 }
                             }
 
@@ -476,7 +477,8 @@ public class RNSensitiveInfoModule extends ReactContextBaseJavaModule {
 
                                 @Override
                                 public void onAuthenticationFailed() {
-                                    pm.reject(AppConstants.E_AUTHENTICATION_NOT_RECOGNIZED, strings.containsKey("notRecognized") ? strings.get("notRecognized").toString() : "Fingerprint not recognized, try again");
+                                    getReactApplicationContext().getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                                            .emit("FINGERPRINT_AUTHENTICATION_HELP", "Fingerprint not recognized.");
                                 }
                             }
 

--- a/android/src/main/java/br/com/classapp/RNSensitiveInfo/utils/AppConstants.java
+++ b/android/src/main/java/br/com/classapp/RNSensitiveInfo/utils/AppConstants.java
@@ -5,7 +5,6 @@ public interface AppConstants {
     String DIALOG_FRAGMENT_TAG = "authFragment";
 
     // error codes
-    String E_AUTHENTICATION_NOT_RECOGNIZED = "E_AUTHENTICATION_NOT_RECOGNIZED";
     String E_AUTHENTICATION_CANCELLED = "E_AUTHENTICATION_CANCELLED";
     String E_INIT_FAILURE = "E_INIT_FAILURE";
 }


### PR DESCRIPTION
When showModal is false it isn't rejecting the promise.
This emits the same event when a failed callback is triggered