### PR TITLE
fix(android): Android 11 auth required check

### DIFF
--- a/android/src/main/java/dev/mcodex/RNSensitiveInfoModule.java
+++ b/android/src/main/java/dev/mcodex/RNSensitiveInfoModule.java
@@ -409,7 +409,7 @@ public class RNSensitiveInfoModule extends ReactContextBaseJavaModule {
                     KeyInfo info = (KeyInfo) factory.getKeySpec(secretKey, KeyInfo.class);
 
                     if (info.isUserAuthenticationRequired() &&
-                            info.getUserAuthenticationValidityDurationSeconds() == -1) {
+                            info.getUserAuthenticationValidityDurationSeconds() <= 0) {
 
                         if (showModal) {
                             class PutExtraWithAESCallback extends BiometricPrompt.AuthenticationCallback {
@@ -535,7 +535,7 @@ public class RNSensitiveInfoModule extends ReactContextBaseJavaModule {
                     KeyInfo info = (KeyInfo) factory.getKeySpec(secretKey, KeyInfo.class);
 
                     if (info.isUserAuthenticationRequired() &&
-                            info.getUserAuthenticationValidityDurationSeconds() == -1) {
+                            info.getUserAuthenticationValidityDurationSeconds() <= 0) {
 
                         if (showModal) {
                             class DecryptWithAesCallback extends BiometricPrompt.AuthenticationCallback {


### PR DESCRIPTION
## Description
running on Android OS 11 on Pixel 3
getUserAuthenticationValidityDurationSeconds returned 0 instead of -1
updated check to not bypass authentication

## Test
* run example application on device with Android 11 and fingerprint enabled
* clicking add item with Touch ID and get item with Touch ID should show alerts
