### PR TITLE
fix: named exports for v5 compatibility

### DIFF
--- a/RNSensitiveInfo.ts
+++ b/RNSensitiveInfo.ts
@@ -2,24 +2,16 @@ import { NativeModules } from 'react-native';
 
 const { RNSensitiveInfo } = NativeModules;
 
-export default {
-  ...RNSensitiveInfo,
-  // setInvalidatedByBiometricEnrollment(
-  //   invalidatedByBiometricEnrollment
-  // ): Function {
-  //   if (RNSensitiveInfo.setInvalidatedByBiometricEnrollment == null) {
-  //     return;
-  //   }
+export const {
+  setItem,
+  getItem,
+  hasItem,
+  getAllItems,
+  deleteItem,
+  isSensorAvailable,
+  hasEnrolledFingerprints,
+  cancelFingerprintAuth,
+  setInvalidatedByBiometricEnrollment,
+} = RNSensitiveInfo;
 
-  //   return RNSensitiveInfo.setInvalidatedByBiometricEnrollment(
-  //     invalidatedByBiometricEnrollment
-  //   );
-  // },
-  // cancelFingerprintAuth() {
-  //   if (RNSensitiveInfo.cancelFingerprintAuth == null) {
-  //     return;
-  //   }
-
-  //   return RNSensitiveInfo.cancelFingerprintAuth();
-  // },
-};
+export default RNSensitiveInfo;


### PR DESCRIPTION
The change from module.exports to export default no longer allows you to use named imports. This would be a breaking change, but it's also incompatible with the current type declarations.

This could be fixed using commonjs module and 'export =' in TypeScript, but this is incompatible with Rollup. The simplest answer seems to be just explicitly using named exports based on the type declarations as well as including the default export.

Fixes #291 