### PR TITLE
Make Error 'cause' non-enumerable and add tests

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   push:
     branches:
-      - main
+      - master
     paths:
       - '.github/workflows/android-build.yml'
       - 'example/android/**'

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   push:
     branches:
-      - main
+      - master
     paths:
       - '.github/workflows/ios-build.yml'
       - 'example/ios/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   push:
     branches:
-      - main
+      - master
     paths:
       - '.github/workflows/test.yml'
       - 'src/**'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
 	"sideEffects": false,
 	"exports": {
 		".": {
-			"react-native": "./src/index.ts",
 			"import": {
 				"types": "./lib/typescript/module/src/index.d.ts",
 				"default": "./lib/module/index.js"
@@ -22,7 +21,6 @@
 			"default": "./lib/module/index.js"
 		},
 		"./hooks": {
-			"react-native": "./src/hooks/index.ts",
 			"import": {
 				"types": "./lib/typescript/module/src/hooks/index.d.ts",
 				"default": "./lib/module/hooks/index.js"
@@ -34,7 +32,6 @@
 			"default": "./lib/module/hooks/index.js"
 		},
 		"./errors": {
-			"react-native": "./src/errors.ts",
 			"import": {
 				"types": "./lib/typescript/module/src/errors.d.ts",
 				"default": "./lib/module/errors.js"

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -88,6 +88,18 @@ describe('errors', () => {
 				expect(Object.hasOwn(err, 'cause')).toBe(false)
 			})
 
+			it('defines a non-enumerable own cause when explicitly passed as undefined', () => {
+				const err = new SensitiveInfoError(ErrorCode.NotFound, 'wrapped', {
+					cause: undefined,
+				})
+				const descriptor = Object.getOwnPropertyDescriptor(err, 'cause')
+				expect(Object.hasOwn(err, 'cause')).toBe(true)
+				expect(err.cause).toBeUndefined()
+				expect(descriptor).toBeDefined()
+				expect(descriptor?.enumerable).toBe(false)
+				expect(Object.keys(err)).not.toContain('cause')
+			})
+
 			it('propagates cause through subclasses (NotFoundError)', () => {
 				const cause = new Error('native miss')
 				const err = new NotFoundError('missing', { cause })

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -61,6 +61,39 @@ describe('errors', () => {
 			const err = new KeyInvalidatedError('invalid', { alias: 'rnsi.svc.v1' })
 			expect(err.alias).toBe('rnsi.svc.v1')
 		})
+
+		describe('cause chaining', () => {
+			it('retains the provided cause on SensitiveInfoError', () => {
+				const cause = new Error('underlying')
+				const err = new SensitiveInfoError(ErrorCode.NotFound, 'wrapped', {
+					cause,
+				})
+				expect(err.cause).toBe(cause)
+			})
+
+			it('keeps cause non-enumerable to match native ES2022 Error semantics', () => {
+				const cause = new Error('underlying')
+				const err = new SensitiveInfoError(ErrorCode.NotFound, 'wrapped', {
+					cause,
+				})
+				const descriptor = Object.getOwnPropertyDescriptor(err, 'cause')
+				expect(descriptor).toBeDefined()
+				expect(descriptor?.enumerable).toBe(false)
+				expect(Object.keys(err)).not.toContain('cause')
+				expect(JSON.parse(JSON.stringify(err))).not.toHaveProperty('cause')
+			})
+
+			it('does not define cause when not provided', () => {
+				const err = new SensitiveInfoError(ErrorCode.NotFound, 'wrapped')
+				expect(Object.hasOwn(err, 'cause')).toBe(false)
+			})
+
+			it('propagates cause through subclasses (NotFoundError)', () => {
+				const cause = new Error('native miss')
+				const err = new NotFoundError('missing', { cause })
+				expect(err.cause).toBe(cause)
+			})
+		})
 	})
 
 	describe('toSensitiveInfoError', () => {

--- a/src/__tests__/hooks.types.test.ts
+++ b/src/__tests__/hooks.types.test.ts
@@ -19,6 +19,22 @@ describe('hooks/types', () => {
 		expect(error.hint).toBe('Check the key.')
 	})
 
+	it('keeps cause non-enumerable to match native ES2022 Error semantics', () => {
+		const cause = new Error('native failure')
+		const error = new HookError('Wrapper message', { cause })
+
+		const descriptor = Object.getOwnPropertyDescriptor(error, 'cause')
+		expect(descriptor).toBeDefined()
+		expect(descriptor?.enumerable).toBe(false)
+		expect(Object.keys(error)).not.toContain('cause')
+		expect(JSON.parse(JSON.stringify(error))).not.toHaveProperty('cause')
+	})
+
+	it('omits cause when not provided', () => {
+		const error = new HookError('Wrapper message')
+		expect(Object.hasOwn(error, 'cause')).toBe(false)
+	})
+
 	it('creates the initial async state', () => {
 		const state = createInitialAsyncState<string>()
 		expect(state).toEqual({

--- a/src/__tests__/hooks.types.test.ts
+++ b/src/__tests__/hooks.types.test.ts
@@ -35,6 +35,16 @@ describe('hooks/types', () => {
 		expect(Object.hasOwn(error, 'cause')).toBe(false)
 	})
 
+	it('defines a non-enumerable own cause when explicitly passed as undefined', () => {
+		const error = new HookError('Wrapper message', { cause: undefined })
+		const descriptor = Object.getOwnPropertyDescriptor(error, 'cause')
+		expect(Object.hasOwn(error, 'cause')).toBe(true)
+		expect(error.cause).toBeUndefined()
+		expect(descriptor).toBeDefined()
+		expect(descriptor?.enumerable).toBe(false)
+		expect(Object.keys(error)).not.toContain('cause')
+	})
+
 	it('creates the initial async state', () => {
 		const state = createInitialAsyncState<string>()
 		expect(state).toEqual({

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -75,11 +75,17 @@ export class SensitiveInfoError extends Error {
 		super(message)
 		this.name = 'SensitiveInfoError'
 		this.code = code
-		// Assign `cause` directly instead of passing it to `super()` so this
+		// Define `cause` manually instead of passing it to `super()` so this
 		// compiles cleanly under TS configs whose `lib` predates ES2022 (where
-		// the second `Error` constructor argument was introduced).
+		// the second `Error` constructor argument was introduced), while keeping
+		// the property non-enumerable to match the native ES2022 `Error` constructor.
 		if (options && 'cause' in options) {
-			;(this as { cause?: unknown }).cause = options.cause
+			Object.defineProperty(this, 'cause', {
+				value: options.cause,
+				writable: true,
+				configurable: true,
+				enumerable: false,
+			})
 		}
 	}
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -63,6 +63,16 @@ export class SensitiveInfoError extends Error {
 	readonly code: ErrorCodeValue
 
 	/**
+	 * The underlying cause forwarded to {@link Error.cause}.
+	 *
+	 * Declared as a type-only member so the property type-checks under `tsconfig`
+	 * `lib` targets that predate ES2022 (where {@link Error} did not yet expose
+	 * `cause`). At runtime the value is installed by the constructor via
+	 * {@link Object.defineProperty} so it stays non-enumerable.
+	 */
+	declare readonly cause?: unknown
+
+	/**
 	 * @param code    - Stable {@link ErrorCodeValue} for the failure.
 	 * @param message - Human-readable description.
 	 * @param options - Optional `cause` for error chaining (see ECMAScript 2022 `Error` cause).

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -42,11 +42,17 @@ export class HookError extends Error {
 		this.name = 'HookError'
 		this.operation = operation
 		this.hint = hint
-		// Assign `cause` directly instead of passing it to `super()` so this
+		// Define `cause` manually instead of passing it to `super()` so this
 		// compiles cleanly under TS configs whose `lib` predates ES2022 (where
-		// the second `Error` constructor argument was introduced).
+		// the second `Error` constructor argument was introduced), while keeping
+		// the property non-enumerable to match the native ES2022 `Error` constructor.
 		if (cause !== undefined) {
-			;(this as { cause?: unknown }).cause = cause
+			Object.defineProperty(this, 'cause', {
+				value: cause,
+				writable: true,
+				configurable: true,
+				enumerable: false,
+			})
 		}
 	}
 }

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -31,24 +31,35 @@ export class HookError extends Error {
 	readonly hint?: string | undefined
 
 	/**
+	 * The underlying cause forwarded to {@link Error.cause}.
+	 *
+	 * Declared as a type-only member so the property type-checks under `tsconfig`
+	 * `lib` targets that predate ES2022 (where {@link Error} did not yet expose
+	 * `cause`). At runtime the value is installed by the constructor via
+	 * {@link Object.defineProperty} so it stays non-enumerable.
+	 */
+	declare readonly cause?: unknown
+
+	/**
 	 * @param message - Human-readable description of the failure.
 	 * @param options - Additional metadata; see {@link HookErrorOptions}.
 	 */
-	constructor(
-		message: string,
-		{ cause, operation, hint }: HookErrorOptions = {}
-	) {
+	constructor(message: string, options: HookErrorOptions = {}) {
 		super(message)
 		this.name = 'HookError'
-		this.operation = operation
-		this.hint = hint
+		this.operation = options.operation
+		this.hint = options.hint
 		// Define `cause` manually instead of passing it to `super()` so this
 		// compiles cleanly under TS configs whose `lib` predates ES2022 (where
 		// the second `Error` constructor argument was introduced), while keeping
 		// the property non-enumerable to match the native ES2022 `Error` constructor.
-		if (cause !== undefined) {
+		//
+		// We deliberately use `'cause' in options` (rather than a value check)
+		// so that `new HookError(msg, { cause: undefined })` still installs the
+		// property — matching native `new Error(msg, { cause: undefined })`.
+		if ('cause' in options) {
 			Object.defineProperty(this, 'cause', {
-				value: cause,
+				value: options.cause,
 				writable: true,
 				configurable: true,
 				enumerable: false,


### PR DESCRIPTION
This pull request updates workflow branch targets and improves the handling of error causes in custom error classes to better align with ES2022 Error semantics. The most significant changes include switching workflow triggers from the `main` to the `master` branch and ensuring that the `cause` property on custom errors is non-enumerable and only defined when provided, matching native JavaScript behavior.

**Workflow configuration updates:**

- Changed the workflow triggers in `.github/workflows/android-build.yml`, `.github/workflows/ios-build.yml`, and `.github/workflows/test.yml` to use the `master` branch instead of `main`. [[1]](diffhunk://#diff-49b2d9cefb8c056411b766cd738211a9ec2c54615fb3e69d4c7b529d7f7cc268L9-R9) [[2]](diffhunk://#diff-49cb7cd48bffe52ea29a444d73bb18f47a73b4a243a5df0c25c6a57d7b18130bL9-R9) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L9-R9)

**Error handling improvements:**

- Updated `SensitiveInfoError` in `src/errors.ts` and `HookError` in `src/hooks/types.ts` to define the `cause` property using `Object.defineProperty`, making it non-enumerable and only present when actually provided, to match native ES2022 `Error` behavior. [[1]](diffhunk://#diff-55db69e02ff5714d444d8081ec6ecac5d9833fb29fda64d1e829e5766434fdc0L78-R88) [[2]](diffhunk://#diff-cfb57008d0416386102692f6aed5eef271c405a50dd824e59ced51d907e54daeL45-R55)

**Testing enhancements:**

- Added and extended tests in `src/__tests__/errors.test.ts` and `src/__tests__/hooks.types.test.ts` to verify that the `cause` property is correctly handled—ensuring it is retained, non-enumerable, omitted when not given, and propagated through subclasses. [[1]](diffhunk://#diff-78a3cd5f4e9a87b16bb2e2a109c5bb84433cb0f5c29866ee3fc8098315f696e3R64-R96) [[2]](diffhunk://#diff-c08bc867c3e2af8d294cdeb63d6344737d32a0c1c8f8136f137d9e1d8b359795R22-R37)Define the `cause` property with Object.defineProperty in SensitiveInfoError and HookError so it remains non-enumerable (matching native ES2022 Error semantics) while keeping compatibility with TS libs predating ES2022. Add tests to verify cause chaining, non-enumerability, and omission when not provided. Also update CI workflow triggers to use the 'master' branch for android, ios and test workflows.